### PR TITLE
Change some of the variables in Release Mgmt makefile to use lazy set…

### DIFF
--- a/release-mgmt/release.mk
+++ b/release-mgmt/release.mk
@@ -19,9 +19,9 @@ docker run --rm \
 -it binbash/git-release:0.0.2
 endef
 
-GIT_SEMTAG_VER_PATCH := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s patch -o | grep -v 'Warning: Permanently added the RSA host key for IP address')
-GIT_SEMTAG_VER_MINOR := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s minor -o | grep -v 'Warning: Permanently added the RSA host key for IP address')
-GIT_SEMTAG_VER_MAJOR := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s major -o | grep -v 'Warning: Permanently added the RSA host key for IP address')
+GIT_SEMTAG_VER_PATCH = $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s patch -o | grep -v 'Warning: Permanently added the RSA host key for IP address')
+GIT_SEMTAG_VER_MINOR = $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s minor -o | grep -v 'Warning: Permanently added the RSA host key for IP address')
+GIT_SEMTAG_VER_MAJOR = $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s major -o | grep -v 'Warning: Permanently added the RSA host key for IP address')
 
 help:
 	@echo 'Available Commands:'


### PR DESCRIPTION
… instead of immediate set in order to avoid commands to be run at variable definition time

## what
* Change some of the variables in Release Mgmt makefile to use lazy set instead of immediate set in order to avoid commands to be run at variable definition time

## why
* Some of the variables that define Docker commands were declared using immediate set which caused those commands to be executed at definition time which in turn caused undesired side-effects on MacOS environments (and also triggered command executions that did not need to happen)
