### PR TITLE
BBL-192 | adding auto make decrypt validation to make apply, plan and destroy

### DIFF
--- a/terraform11/terraform11-subfolder.mk
+++ b/terraform11/terraform11-subfolder.mk
@@ -58,6 +58,14 @@ init-cmd:
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
 plan: ## Preview terraform changes
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -65,9 +73,9 @@ plan: ## Preview terraform changes
 
 plan-detailed: ## Preview terraform changes with a more detailed output
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
-	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
+	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 diff: ## Terraform plan with landscape
 	${TF_CMD_PREFIX} plan \
@@ -78,6 +86,14 @@ diff: ## Terraform plan with landscape
 
 apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
 apply-cmd:
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -87,6 +103,14 @@ output: ## Terraform output command is used to extract the value of an output va
 	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} destroy \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform11/terraform11-subfolder.mk
+++ b/terraform11/terraform11-subfolder.mk
@@ -72,6 +72,14 @@ plan: ## Preview terraform changes
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 plan-detailed: ## Preview terraform changes with a more detailed output
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform11/terraform11.mk
+++ b/terraform11/terraform11.mk
@@ -58,6 +58,14 @@ init-cmd:
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
 plan: ## Preview terraform changes
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -65,9 +73,9 @@ plan: ## Preview terraform changes
 
 plan-detailed: ## Preview terraform changes with a more detailed output
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
-	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
+	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 diff: ## Terraform plan with landscape
 	${TF_CMD_PREFIX} plan \
@@ -78,6 +86,14 @@ diff: ## Terraform plan with landscape
 
 apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
 apply-cmd:
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -87,6 +103,14 @@ output: ## Terraform output command is used to extract the value of an output va
 	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} destroy \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform11/terraform11.mk
+++ b/terraform11/terraform11.mk
@@ -72,6 +72,14 @@ plan: ## Preview terraform changes
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 plan-detailed: ## Preview terraform changes with a more detailed output
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform12/terraform12-subfolder.mk
+++ b/terraform12/terraform12-subfolder.mk
@@ -90,6 +90,14 @@ plan: ## Preview terraform changes
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 plan-detailed: ## Preview terraform changes with a more detailed output
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform12/terraform12-subfolder.mk
+++ b/terraform12/terraform12-subfolder.mk
@@ -76,6 +76,14 @@ init-cmd:
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
 plan: ## Preview terraform changes
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -83,12 +91,20 @@ plan: ## Preview terraform changes
 
 plan-detailed: ## Preview terraform changes with a more detailed output
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
-	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
+	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
 apply-cmd:
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -101,6 +117,14 @@ output-json: ## Terraform output json fmt command is used to extract the value o
 	${TF_CMD_PREFIX} output -json
 
 destroy: ## Destroy all resources managed by terraform
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} destroy \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -127,7 +151,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -140,12 +164,12 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} plan -out=plan.tfplan \
 	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	 -var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
-	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE} && \
+	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 	${TF_CMD_PREFIX} show -json plan.tfplan > plan.json
 	@echo ----------------------------------------------------------------------
 	cat plan.json \
@@ -155,7 +179,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------

--- a/terraform12/terraform12.mk
+++ b/terraform12/terraform12.mk
@@ -90,6 +90,14 @@ plan: ## Preview terraform changes
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 plan-detailed: ## Preview terraform changes with a more detailed output
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform12/terraform12.mk
+++ b/terraform12/terraform12.mk
@@ -76,6 +76,14 @@ init-cmd:
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
 plan: ## Preview terraform changes
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -89,6 +97,14 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 
 apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
 apply-cmd:
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -97,7 +113,18 @@ apply-cmd:
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
 	${TF_CMD_PREFIX} output
 
+output-json: ## Terraform output json fmt command is used to extract the value of an output variable from the state file.
+	${TF_CMD_PREFIX} output -json
+
 destroy: ## Destroy all resources managed by terraform
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} destroy \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -124,7 +151,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -137,7 +164,7 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} plan -out=plan.tfplan \
 	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
@@ -152,7 +179,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------

--- a/terraform13/terraform13-subfolder.mk
+++ b/terraform13/terraform13-subfolder.mk
@@ -96,6 +96,14 @@ plan: ## Preview terraform changes
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 plan-detailed: ## Preview terraform changes with a more detailed output
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform13/terraform13-subfolder.mk
+++ b/terraform13/terraform13-subfolder.mk
@@ -82,6 +82,14 @@ init-reconfigure-cmd:
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
 plan: ## Preview terraform changes
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -95,6 +103,14 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 
 apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
 apply-cmd:
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -107,6 +123,14 @@ output-json: ## Terraform output json fmt command is used to extract the value o
 	${TF_CMD_PREFIX} output -json
 
 destroy: ## Destroy all resources managed by terraform
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} destroy \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -133,7 +157,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -146,12 +170,12 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} plan -out=plan.tfplan \
-	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
-	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
-	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE} && \
+	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
+	 -var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
+	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 	${TF_CMD_PREFIX} show -json plan.tfplan > plan.json
 	@echo ----------------------------------------------------------------------
 	cat plan.json \
@@ -161,7 +185,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------

--- a/terraform13/terraform13.mk
+++ b/terraform13/terraform13.mk
@@ -96,6 +96,14 @@ plan: ## Preview terraform changes
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
 plan-detailed: ## Preview terraform changes with a more detailed output
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan -detailed-exitcode \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform13/terraform13.mk
+++ b/terraform13/terraform13.mk
@@ -82,6 +82,14 @@ init-reconfigure-cmd:
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
 plan: ## Preview terraform changes
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} plan \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -95,6 +103,14 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 
 apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
 apply-cmd:
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -103,7 +119,18 @@ apply-cmd:
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
 	${TF_CMD_PREFIX} output
 
+output-json: ## Terraform output json fmt command is used to extract the value of an output variable from the state file.
+	${TF_CMD_PREFIX} output -json
+
 destroy: ## Destroy all resources managed by terraform
+	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
+		echo "===============================================";\
+		echo "Decrypting secrets before running 'make apply',";\
+		echo "please enter your ansible-vault encryption key ";\
+		echo "===============================================";\
+		make decrypt;\
+	fi
+
 	${TF_CMD_PREFIX} destroy \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -130,7 +157,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -143,7 +170,7 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} plan -out=plan.tfplan \
 	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
@@ -158,7 +185,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------


### PR DESCRIPTION
### What?
#### Commits on Oct 22, 2020
- @exequielrafaela - BBL-192 | adding auto make decrypt validation to make apply, plan and destroy - 06415ee
- @exequielrafaela - BBL-192 | adding make decrypt validation conditional to tf plan-detailed cmd - da0a060

### Why?
- Improve workflow and UX for Leverage Ref Architecture terraform layers containing ansible-vault encrypted files.  