### PR TITLE
Feature/BBL-242 | ansible makefiles integrated with leverage ansible docker image

### DIFF
--- a/ansible/ansible-roles.mk
+++ b/ansible/ansible-roles.mk
@@ -1,5 +1,3 @@
--include ../../@bin/config/base.mk
-
 .PHONY: help
 SHELL               := /bin/bash
 

--- a/ansible/ansible.mk
+++ b/ansible/ansible.mk
@@ -44,9 +44,6 @@ endef
 # ANSIBLE VARS
 ANSIBLE_TAGS = $$(echo $@ | cut -d "-" -f 2- | sed "s/%*$$//")
 
-PY_PIP_VER := 20.2.4
-PY_ANSIBLE_VER := 2.10.1
-
 help:
 	@echo 'Available Commands:'
 	@egrep '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":"}; { if ($$3 == "") { printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2 } else { printf " - \033[36m%-18s\033[0m %s\n", $$2, $$3 }}'
@@ -82,6 +79,7 @@ decrypt-cmd:
 decrypt-string: ## Decrypt encrypted string via ansible-vault - e.g. make ARG="your_encrypted_srting" decrypt-string
 	${ANSIBLE_CMD_PREFIX} bash ../@bin/scripts/ansible-vault-decrypt-str.sh ${ARG}
 
-encrypt: ## Encrypt secrets.dec.tf via ansible-vault
+encrypt: encrypt-cmd pwd-dir-chmod ## Encrypt secrets.dec.tf via ansible-vault
+encrypt-cmd:
 	${ANSIBLE_CMD_PREFIX} ansible-vault encrypt --output ./group_vars/secrets.enc.yml ./group_vars/secrets.dec.yml \
 	&& rm -rf ./group_vars/secrets.dec.yml

--- a/ansible/ansible.mk
+++ b/ansible/ansible.mk
@@ -56,6 +56,7 @@ pwd-dir-chown: ## run chown in ./roles to grant that the docker mounted dir has 
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./roles
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./group_vars
+
 shell: ## Initialize terraform backend, plugins, and modules
 	${ANSIBLE_CMD_BASH_PREFIX}
 

--- a/ansible/ansible.mk
+++ b/ansible/ansible.mk
@@ -1,7 +1,45 @@
--include ../../@bin/config/base.mk
+-include ../@bin/config/base.mk
 
 .PHONY: help
 SHELL := /bin/bash
+
+LOCAL_OS_USER_ID					= $(shell id -u)
+LOCAL_OS_GROUP_ID					= $(shell id -g)
+LOCAL_OS_SSH_DIR					:= ~/.ssh/${PROJECT_SHORT}
+LOCAL_OS_GIT_CONF_DIR     := ~/.gitconfig
+
+ANSIBLE_PWD_ROOT_DIR			= $(shell cd .. && pwd)
+ANSIBLE_PWD_PLAY_DIR      = $(shell pwd | rev | cut -d '/' -f 1 | rev)
+ANSIBLE_DOCKER_ENTRYPOINT :=
+ANSIBLE_CONT_USER 				:= root
+ANSIBLE_CONT_PWD_DIR			:= /${ANSIBLE_CONT_USER}/ansible
+ANSIBLE_VAULT_FILE				:= ~/.ansible/vault/${PROJECT_SHORT}
+ANSIBLE_VER								:= 2.10.3
+ANSIBLE_DOCKER_IMAGE			:= binbash/ansible
+
+define ANSIBLE_CMD_PREFIX
+docker run --rm \
+-v ${ANSIBLE_PWD_ROOT_DIR}:${ANSIBLE_CONT_PWD_DIR}:rw \
+-v ${LOCAL_OS_SSH_DIR}:/${ANSIBLE_CONT_USER}/.ssh/${PROJECT_SHORT} \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${ANSIBLE_VAULT_FILE}:/${ANSIBLE_CONT_USER}/.ansible/vault/${PROJECT_SHORT} \
+-w ${ANSIBLE_CONT_PWD_DIR}/${ANSIBLE_PWD_PLAY_DIR} \
+-e no_proxy="*" \
+--entrypoint=${ANSIBLE_DOCKER_ENTRYPOINT} \
+-it ${ANSIBLE_DOCKER_IMAGE}:${ANSIBLE_VER}
+endef
+
+define ANSIBLE_CMD_BASH_PREFIX
+docker run --rm \
+-v ${ANSIBLE_PWD_ROOT_DIR}:${ANSIBLE_CONT_PWD_DIR}:rw \
+-v ${LOCAL_OS_SSH_DIR}:/${ANSIBLE_CONT_USER}/.ssh/${PROJECT_SHORT} \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${ANSIBLE_VAULT_FILE}:/${ANSIBLE_CONT_USER}/.ansible/vault/${PROJECT_SHORT} \
+-e no_proxy="*" \
+--entrypoint=bash \
+-w ${ANSIBLE_CONT_PWD_DIR}/${ANSIBLE_PWD_PLAY_DIR} \
+-it ${ANSIBLE_DOCKER_IMAGE}:${ANSIBLE_VER}
+endef
 
 # ANSIBLE VARS
 ANSIBLE_TAGS = $$(echo $@ | cut -d "-" -f 2- | sed "s/%*$$//")
@@ -16,28 +54,34 @@ help:
 #==============================================================#
 # ANSIBLE                                                      #
 #==============================================================#
-init-ansible-py: ## Install required ansible version
-		pip3 install  --use-feature=2020-resolver --user --upgrade pip==${PY_PIP_VER}
-		pip3 install  --use-feature=2020-resolver --user -I ansible==${PY_ANSIBLE_VER}
+pwd-dir-chmod: ## run chown in ./roles to grant that the docker mounted dir has the right permissions
+	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
+	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
+	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./roles
+	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./group_vars
+shell: ## Initialize terraform backend, plugins, and modules
+	${ANSIBLE_CMD_BASH_PREFIX}
 
-init: ## Install required ansible roles
-	ansible-galaxy install -f -r requirements.yml --roles-path ./roles/
+init: init-cmd pwd-dir-chmod ## Install required ansible roles
+init-cmd:
+	${ANSIBLE_CMD_PREFIX} ansible-galaxy install -f -r requirements.yml --roles-path ./roles/
 
 apply: ## run ansible-playbook
-	no_proxy="*" ansible-playbook setup.yml
+	${ANSIBLE_CMD_PREFIX} ansible-playbook setup.yml
 
 apply-%: ## Provision only the given tags (e.g. make apply-security-users or make apply-openvpn-pritunl)
-	no_proxy="*" ansible-playbook setup.yml --tags $(ANSIBLE_TAGS)
+	${ANSIBLE_CMD_PREFIX} ansible-playbook setup.yml --tags $(ANSIBLE_TAGS)
 
 check: ## run ansible-playbook in Check Mode (“Dry Run”)
-	ansible-playbook setup.yml --check
+	${ANSIBLE_CMD_PREFIX} ansible-playbook setup.yml --check
 
-decrypt: ## Decrypt secrets.tf via ansible-vault
-	ansible-vault decrypt --output ./group_vars/secrets.dec.yml ./group_vars/secrets.enc.yml
+decrypt: decrypt-cmd pwd-dir-chmod ## Decrypt secrets.tf via ansible-vault
+decrypt-cmd:
+	${ANSIBLE_CMD_PREFIX} ansible-vault decrypt --output ./group_vars/secrets.dec.yml ./group_vars/secrets.enc.yml
 
 decrypt-string: ## Decrypt encrypted string via ansible-vault - e.g. make ARG="your_encrypted_srting" decrypt-string
-	bash ../@bin/scripts/ansible-vault-decrypt-str.sh ${ARG}
+	${ANSIBLE_CMD_PREFIX} bash ../@bin/scripts/ansible-vault-decrypt-str.sh ${ARG}
 
 encrypt: ## Encrypt secrets.dec.tf via ansible-vault
-	ansible-vault encrypt --output ./group_vars/secrets.enc.yml ./group_vars/secrets.dec.yml \
+	${ANSIBLE_CMD_PREFIX} ansible-vault encrypt --output ./group_vars/secrets.enc.yml ./group_vars/secrets.dec.yml \
 	&& rm -rf ./group_vars/secrets.dec.yml

--- a/ansible/ansible.mk
+++ b/ansible/ansible.mk
@@ -51,7 +51,7 @@ help:
 #==============================================================#
 # ANSIBLE                                                      #
 #==============================================================#
-pwd-dir-chmod: ## run chown in ./roles to grant that the docker mounted dir has the right permissions
+pwd-dir-chown: ## run chown in ./roles to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./roles
@@ -59,7 +59,7 @@ pwd-dir-chmod: ## run chown in ./roles to grant that the docker mounted dir has 
 shell: ## Initialize terraform backend, plugins, and modules
 	${ANSIBLE_CMD_BASH_PREFIX}
 
-init: init-cmd pwd-dir-chmod ## Install required ansible roles
+init: init-cmd pwd-dir-chown ## Install required ansible roles
 init-cmd:
 	${ANSIBLE_CMD_PREFIX} ansible-galaxy install -f -r requirements.yml --roles-path ./roles/
 
@@ -72,14 +72,14 @@ apply-%: ## Provision only the given tags (e.g. make apply-security-users or mak
 check: ## run ansible-playbook in Check Mode (“Dry Run”)
 	${ANSIBLE_CMD_PREFIX} ansible-playbook setup.yml --check
 
-decrypt: decrypt-cmd pwd-dir-chmod ## Decrypt secrets.tf via ansible-vault
+decrypt: decrypt-cmd pwd-dir-chown ## Decrypt secrets.tf via ansible-vault
 decrypt-cmd:
 	${ANSIBLE_CMD_PREFIX} ansible-vault decrypt --output ./group_vars/secrets.dec.yml ./group_vars/secrets.enc.yml
 
 decrypt-string: ## Decrypt encrypted string via ansible-vault - e.g. make ARG="your_encrypted_srting" decrypt-string
 	${ANSIBLE_CMD_PREFIX} bash ../@bin/scripts/ansible-vault-decrypt-str.sh ${ARG}
 
-encrypt: encrypt-cmd pwd-dir-chmod ## Encrypt secrets.dec.tf via ansible-vault
+encrypt: encrypt-cmd pwd-dir-chown ## Encrypt secrets.dec.tf via ansible-vault
 encrypt-cmd:
 	${ANSIBLE_CMD_PREFIX} ansible-vault encrypt --output ./group_vars/secrets.enc.yml ./group_vars/secrets.dec.yml \
 	&& rm -rf ./group_vars/secrets.dec.yml

--- a/terraform11/terraform11-subfolder.mk
+++ b/terraform11/terraform11-subfolder.mk
@@ -42,7 +42,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform11/terraform11-subfolder.mk
+++ b/terraform11/terraform11-subfolder.mk
@@ -42,7 +42,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -52,7 +52,7 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
@@ -92,7 +92,7 @@ diff: ## Terraform plan with landscape
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE} \
 	| docker run -i --rm binbash/terraform-landscape
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
 		echo "===============================================";\

--- a/terraform11/terraform11.mk
+++ b/terraform11/terraform11.mk
@@ -42,7 +42,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform11/terraform11.mk
+++ b/terraform11/terraform11.mk
@@ -42,7 +42,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -52,7 +52,7 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
@@ -92,7 +92,7 @@ diff: ## Terraform plan with landscape
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE} \
 	| docker run -i --rm binbash/terraform-landscape
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
 		echo "===============================================";\

--- a/terraform12/terraform12-mfa.mk
+++ b/terraform12/terraform12-mfa.mk
@@ -66,7 +66,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform12/terraform12-mfa.mk
+++ b/terraform12/terraform12-mfa.mk
@@ -66,7 +66,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -77,7 +77,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 version: ## Show terraform version
 	${TF_CMD_MFA_PREFIX} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_MFA_PREFIX} init \
 		-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
@@ -94,7 +94,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 		-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 		-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	${TF_CMD_MFA_PREFIX} apply \
 		-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \

--- a/terraform12/terraform12-no-warn.mk
+++ b/terraform12/terraform12-no-warn.mk
@@ -42,7 +42,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform12/terraform12-no-warn.mk
+++ b/terraform12/terraform12-no-warn.mk
@@ -42,7 +42,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -52,7 +52,7 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
@@ -71,7 +71,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	 -var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE} \
 	 -compact-warnings
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \

--- a/terraform12/terraform12-subfolder.mk
+++ b/terraform12/terraform12-subfolder.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -70,7 +70,7 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
@@ -103,7 +103,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
 		echo "===============================================";\

--- a/terraform12/terraform12-subfolder.mk
+++ b/terraform12/terraform12-subfolder.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform12/terraform12.mk
+++ b/terraform12/terraform12.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -70,7 +70,7 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
@@ -103,7 +103,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
 		echo "===============================================";\

--- a/terraform12/terraform12.mk
+++ b/terraform12/terraform12.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform13/terraform13-github.mk
+++ b/terraform13/terraform13-github.mk
@@ -60,7 +60,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -73,12 +73,12 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
-init-reconfigure: init-reconfigure-cmd tf-dir-chmod ## Initialize and reconfigure terraform backend, plugins, and modules
+init-reconfigure: init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 init-reconfigure-cmd:
 	${TF_CMD_PREFIX} init \
 	-reconfigure \
@@ -96,7 +96,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_GITHUB_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \

--- a/terraform13/terraform13-github.mk
+++ b/terraform13/terraform13-github.mk
@@ -60,7 +60,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform13/terraform13-mfa-subfolder.mk
+++ b/terraform13/terraform13-mfa-subfolder.mk
@@ -68,7 +68,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -79,12 +79,12 @@ shell: ## Initialize terraform backend, plugins, and modules
 version: ## Show terraform version
 	${TF_CMD_MFA_PREFIX} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_MFA_PREFIX} init \
 		-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
-init-reconfigure: init-reconfigure-cmd tf-dir-chmod ## Initialize and reconfigure terraform backend, plugins, and modules
+init-reconfigure: init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 init-reconfigure-cmd:
 	${TF_CMD_MFA_PREFIX} init \
 	-reconfigure \
@@ -102,7 +102,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 		-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 		-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	${TF_CMD_MFA_PREFIX} apply \
 		-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \

--- a/terraform13/terraform13-mfa-subfolder.mk
+++ b/terraform13/terraform13-mfa-subfolder.mk
@@ -68,7 +68,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform13/terraform13-mfa.mk
+++ b/terraform13/terraform13-mfa.mk
@@ -68,7 +68,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -79,12 +79,12 @@ shell: ## Initialize terraform backend, plugins, and modules
 version: ## Show terraform version
 	${TF_CMD_MFA_PREFIX} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_MFA_PREFIX} init \
 		-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
-init-reconfigure: init-reconfigure-cmd tf-dir-chmod ## Initialize and reconfigure terraform backend, plugins, and modules
+init-reconfigure: init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 init-reconfigure-cmd:
 	${TF_CMD_MFA_PREFIX} init \
 	-reconfigure \
@@ -102,7 +102,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 		-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 		-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	${TF_CMD_MFA_PREFIX} apply \
 		-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \

--- a/terraform13/terraform13-mfa.mk
+++ b/terraform13/terraform13-mfa.mk
@@ -68,7 +68,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform13/terraform13-subfolder.mk
+++ b/terraform13/terraform13-subfolder.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -70,12 +70,12 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
-init-reconfigure: init-reconfigure-cmd tf-dir-chmod ## Initialize and reconfigure terraform backend, plugins, and modules
+init-reconfigure: init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 init-reconfigure-cmd:
 	${TF_CMD_PREFIX} init \
 	-reconfigure \
@@ -109,7 +109,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
 		echo "===============================================";\

--- a/terraform13/terraform13-subfolder.mk
+++ b/terraform13/terraform13-subfolder.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform

--- a/terraform13/terraform13.mk
+++ b/terraform13/terraform13.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -70,12 +70,12 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
-init-reconfigure: init-reconfigure-cmd tf-dir-chmod ## Initialize and reconfigure terraform backend, plugins, and modules
+init-reconfigure: init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 init-reconfigure-cmd:
 	${TF_CMD_PREFIX} init \
 	-reconfigure \
@@ -109,7 +109,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_ACCOUNT_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	@if [ -f ./*.enc ] && [ ! -f ./*.dec.tf ]; then\
 		echo "===============================================";\

--- a/terraform13/terraform13.mk
+++ b/terraform13/terraform13.mk
@@ -57,7 +57,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chmod: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform


### PR DESCRIPTION
### What? 
Ansible docker image integration to address -> https://github.com/binbashar/le-ansible-infra/issues/17

#### Commits on Nov 11, 2020
- @exequielrafaela - BBL-242 | correcting minor in-line comment typo - 47d9578
- @exequielrafaela - BBL-242 | ansible.mk updated to use new docker image approach - 752e4ed
- @exequielrafaela - BBL-242 | encrypt cmd post chown added - e94c3b7
- @exequielrafaela - BBL-242 | minor in-line comment correction chmod per chown - 9eb740a
- @exequielrafaela - BBL-242 | adding missing space at ansible.mk - 27e6068

### Why?
As exposed at https://github.com/binbashar/le-ansible-infra/issues/17
1. The dockerized Makefile should simplify cmd excecutions and "impose / grant" Binbash Leverage conventions.
2. Standardizing local-env to speed up the on boarding / ramp-up
3. Speed up Leverage development and Binbash Customer Engineers implementation times.
4. In this way we could sum more people to our workflow rapidly, adding the right documentation can reduce the training and KT times.