### PR TITLE
Feature/BBL-192 | Terraform and Ansible docker run updated for selinux hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       docker_layer_caching: false
 
     environment:
-      VERSION_NUMBER: patch # opts: patch, minor or major.
+      VERSION_NUMBER: minor # opts: patch, minor or major.
 
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 -include ../../@bin/config/base.mk
 
 .PHONY: help
-SHELL                    := /bin/bash
-MAKEFILE_PATH            := ./Makefile
-MAKEFILES_DIR            := ./@bin/makefiles
+SHELL         := /bin/bash
+MAKEFILE_PATH := ./Makefile
+MAKEFILES_DIR := ./@bin/makefiles
+MAKEFILES_VER := v0.0.68
 
 help:
 	@echo 'Available Commands:'
@@ -15,7 +16,8 @@ help:
 init-makefiles: ## initialize makefiles
 	rm -rf ${MAKEFILES_DIR}
 	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
+	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR} -q
+	cd ${MAKEFILES_DIR} && git checkout ${MAKEFILES_VER} -q
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk

--- a/ansible/ansible.mk
+++ b/ansible/ansible.mk
@@ -18,7 +18,7 @@ ANSIBLE_VER								:= 2.10.3
 ANSIBLE_DOCKER_IMAGE			:= binbash/ansible
 
 define ANSIBLE_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${ANSIBLE_PWD_ROOT_DIR}:${ANSIBLE_CONT_PWD_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/${ANSIBLE_CONT_USER}/.ssh/${PROJECT_SHORT} \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -30,7 +30,7 @@ docker run --rm \
 endef
 
 define ANSIBLE_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${ANSIBLE_PWD_ROOT_DIR}:${ANSIBLE_CONT_PWD_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/${ANSIBLE_CONT_USER}/.ssh/${PROJECT_SHORT} \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \

--- a/terraform11/terraform11-subfolder.mk
+++ b/terraform11/terraform11-subfolder.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /usr/local/go/bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -48,7 +48,7 @@ tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir 
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 

--- a/terraform11/terraform11.mk
+++ b/terraform11/terraform11.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /usr/local/go/bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -48,7 +48,7 @@ tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir 
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 

--- a/terraform12/terraform12-import-rm-subfolder.mk
+++ b/terraform12/terraform12-import-rm-subfolder.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform12/terraform12-import-rm.mk
+++ b/terraform12/terraform12-import-rm.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform12/terraform12-mfa.mk
+++ b/terraform12/terraform12-mfa.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /root/scripts/aws-mfa/aws-mfa-entrypoint.sh
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -40,7 +40,7 @@ docker run --rm \
 endef
 
 define TF_CMD_MFA_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -121,13 +121,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	# ${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform12/terraform12-no-warn.mk
+++ b/terraform12/terraform12-no-warn.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -48,7 +48,7 @@ tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir 
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -95,13 +95,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform12/terraform12-root-context.mk
+++ b/terraform12/terraform12-root-context.mk
@@ -16,7 +16,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -36,7 +36,7 @@ help:
 # TERRAFORM                                                    #
 #==============================================================#
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -53,13 +53,13 @@ pre-commit: ## Execute validation: pre-commit run --all-files.
 	pre-commit run --all-files
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform12/terraform12-subfolder.mk
+++ b/terraform12/terraform12-subfolder.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -36,7 +36,7 @@ docker run --rm \
 endef
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -66,7 +66,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 	${TF_CMD_BASH_PREFIX}
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -145,13 +145,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform12/terraform12.mk
+++ b/terraform12/terraform12.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -36,7 +36,7 @@ docker run --rm \
 endef
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -66,7 +66,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 	${TF_CMD_BASH_PREFIX}
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -145,13 +145,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13-github.mk
+++ b/terraform13/terraform13-github.mk
@@ -22,7 +22,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -38,7 +38,7 @@ docker run --rm \
 endef
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -69,7 +69,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 	${TF_CMD_BASH_PREFIX}
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -119,13 +119,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13-import-rm-github.mk
+++ b/terraform13/terraform13-import-rm-github.mk
@@ -22,7 +22,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform13/terraform13-import-rm-subfolder.mk
+++ b/terraform13/terraform13-import-rm-subfolder.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform13/terraform13-import-rm.mk
+++ b/terraform13/terraform13-import-rm.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \

--- a/terraform13/terraform13-mfa-github.mk
+++ b/terraform13/terraform13-mfa-github.mk
@@ -23,7 +23,7 @@ TF_DOCKER_ENTRYPOINT             := /root/scripts/aws-mfa/aws-mfa-entrypoint.sh
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -45,7 +45,7 @@ terraform
 endef
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -81,7 +81,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 	${TF_CMD_BASH_PREFIX}
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -131,13 +131,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13-mfa-subfolder.mk
+++ b/terraform13/terraform13-mfa-subfolder.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /root/scripts/aws-mfa/aws-mfa-entrypoint.sh
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -41,7 +41,7 @@ docker run --rm \
 endef
 
 define TF_CMD_MFA_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -129,13 +129,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	# ${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13-mfa.mk
+++ b/terraform13/terraform13-mfa.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /root/scripts/aws-mfa/aws-mfa-entrypoint.sh
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -41,7 +41,7 @@ docker run --rm \
 endef
 
 define TF_CMD_MFA_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/../\@bin/scripts:/root/scripts \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
@@ -129,13 +129,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	# ${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13-root-context.mk
+++ b/terraform13/terraform13-root-context.mk
@@ -16,7 +16,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -36,7 +36,7 @@ help:
 # TERRAFORM                                                    #
 #==============================================================#
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -53,13 +53,13 @@ pre-commit: ## Execute validation: pre-commit run --all-files.
 	pre-commit run --all-files
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13-subfolder.mk
+++ b/terraform13/terraform13-subfolder.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -36,7 +36,7 @@ docker run --rm \
 endef
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -66,7 +66,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 	${TF_CMD_BASH_PREFIX}
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -151,13 +151,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terraform13/terraform13.mk
+++ b/terraform13/terraform13.mk
@@ -21,7 +21,7 @@ TF_DOCKER_ENTRYPOINT             := /bin/terraform
 TF_DOCKER_IMAGE                  := binbash/terraform-awscli-slim
 
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -36,7 +36,7 @@ docker run --rm \
 endef
 
 define TF_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${TF_PWD_CONFIG_DIR}:/config \
 -v ${TF_PWD_COMMON_CONFIG_DIR}/common.config:${TF_DOCKER_COMMON_CONF_VARS_FILE} \
@@ -66,7 +66,7 @@ shell: ## Initialize terraform backend, plugins, and modules
 	${TF_CMD_BASH_PREFIX}
 
 version: ## Show terraform version
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
@@ -151,13 +151,13 @@ format-check: ## The terraform fmt is used to rewrite tf conf files to a canonic
 	${TF_CMD_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0
 
 tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
 	-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
 	-v ${TF_PWD_DIR}:/data \
 	-t wata727/tflint:0.14.0 --deep \

--- a/terratest12/terratest12.mk
+++ b/terratest12/terratest12.mk
@@ -30,7 +30,7 @@ TERRATEST_DOCKER_WORKDIR    := ${TF_PWD_CONT_DIR}/tests
 # TERRAFORM
 #
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
@@ -41,7 +41,7 @@ endef
 # TERRATEST
 #
 define TERRATEST_GO_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -53,7 +53,7 @@ docker run --rm \
 endef
 
 define TERRATEST_GO_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -66,7 +66,7 @@ docker run --rm \
 endef
 
 define TERRATEST_DEP_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -86,7 +86,7 @@ pre-commit: ## Execute validation: pre-commit run --all-files.
 	pre-commit run --all-files
 
 terraform-docs: ## A utility to generate documentation from Terraform 0.12 modules in various output formats.
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
   	-v $$(pwd):/data \
   	cytopia/terraform-docs:0.9.1 \
   	terraform-docs-012 --sort-inputs-by-required --with-aggregate-type-defaults markdown table .

--- a/terratest13/terratest13.mk
+++ b/terratest13/terratest13.mk
@@ -28,7 +28,7 @@ TERRATEST_DOCKER_WORKDIR    := ${TF_PWD_CONT_DIR}/tests
 # TERRAFORM
 #
 define TF_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
@@ -39,7 +39,7 @@ endef
 # TERRATEST
 #
 define TERRATEST_GO_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -51,7 +51,7 @@ docker run --rm \
 endef
 
 define TERRATEST_GO_CMD_BASH_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -64,7 +64,7 @@ docker run --rm \
 endef
 
 define TERRATEST_DEP_CMD_PREFIX
-docker run --rm \
+docker run --security-opt="label:disable" --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
 -v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
 -v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
@@ -84,7 +84,7 @@ pre-commit: ## Execute validation: pre-commit run --all-files.
 	pre-commit run --all-files
 
 terraform-docs: ## A utility to generate documentation from Terraform 0.12 modules in various output formats.
-	docker run --rm \
+	docker run --security-opt="label:disable" --rm \
   	-v $$(pwd):/data \
   	cytopia/terraform-docs:0.9.1 \
   	terraform-docs-012 --sort-inputs-by-required --with-aggregate-type-defaults markdown table .


### PR DESCRIPTION
## What?

Updated `docker run` commands for For **Terraform** and **Ansible** layers to allow hosts using SELinux. 

#### Commits on Nov 13, 2020
- @exequielrafaela - BBL-192 | docker SElinux support -> use –security-opt. This gives it the appropriate security profile, instead of giving away too much permissions within the container. - 1579e86
- @exequielrafaela - BBL-192 | releasing minor ver - bddc36e

## Why?
#### Docker (w/ SElinux)

Since files and processes are tagged with a **SElinux** context,  the container tries and ⚠️  **fail**  to access directories out of context. To overpass this issue you can override the default labeling scheme for each container by specifying the `--security-opt flag`. Specifying the level in the following command allows you to share the same content between containers.

- ✅ For containers which already have **_SELinux/AppArmor_** support, use `–security-opt`. This gives it the appropriate security profile, instead of giving away too much permissions within the container.
   - `docker run --security-opt label:disable --rm ...`

- ⚠️ ❗ **NOT RECOMMENDED** | When the operator executes `docker run --privileged`, Docker will enable access to all devices on the host as well as set some configuration in **_AppArmor_** or **_SELinux_** to allow the container nearly all the same access to the host as processes running outside containers on the host.

## Read More
When docker does the bind mount  and SELinux activated will need to consider the following official docker docs  
- :books: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label If you use selinux you can add the z or Z options to modify the selinux label of the host file or directory being mounted into the container. This affects the file or directory on the host machine itself and can have consequences outside of the scope of Docker.
- :books: https://docs.docker.com/engine/reference/run/#security-configuration