### PR TITLE
BBL-192 | Terraform mfa makefile help output fixed

### DIFF
--- a/terraform12/terraform12-mfa.mk
+++ b/terraform12/terraform12-mfa.mk
@@ -114,11 +114,7 @@ format: ## The terraform fmt is used to rewrite tf conf files to a canonical for
 	${TF_CMD_MFA_PREFIX} fmt -recursive
 
 format-check: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
-	${TF_CMD_MFA_PREFIX} fmt -check
-    # Consider adding -recursive after everything has been migrated to tf-0.12
-	# (should exclude dev/8_k8s_kops/2-kops folder since it's not possible to migrate to
-	# tf-0.12 yet
-	# ${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
+	${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
 	docker run --security-opt="label:disable" --rm \
@@ -135,7 +131,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_MFA_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -148,7 +144,7 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_MFA_PREFIX} plan -out=plan.tfplan \
 	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
@@ -163,7 +159,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_MFA_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------

--- a/terraform13/terraform13-mfa-github.mk
+++ b/terraform13/terraform13-mfa-github.mk
@@ -72,7 +72,7 @@ help:
 #==============================================================#
 # TERRAFORM                                                    #
 #==============================================================#
-tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+tf-dir-chown: ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 	@echo LOCAL_OS_USER_ID: ${LOCAL_OS_USER_ID}
 	@echo LOCAL_OS_GROUP_ID: ${LOCAL_OS_GROUP_ID}
 	sudo chown -R ${LOCAL_OS_USER_ID}:${LOCAL_OS_GROUP_ID} ./.terraform
@@ -85,12 +85,12 @@ version: ## Show terraform version
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-init: init-cmd tf-dir-chmod ## Initialize terraform backend, plugins, and modules
+init: init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 init-cmd:
 	${TF_CMD_PREFIX} init \
 	-backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE}
 
-init-reconfigure: init-reconfigure-cmd tf-dir-chmod ## Initialize and reconfigure terraform backend, plugins, and modules
+init-reconfigure: init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 init-reconfigure-cmd:
 	${TF_CMD_PREFIX} init \
 	-reconfigure \
@@ -108,7 +108,7 @@ plan-detailed: ## Preview terraform changes with a more detailed output
 	-var-file=${TF_DOCKER_COMMON_CONF_VARS_FILE} \
 	-var-file=${TF_DOCKER_GITHUB_CONF_VARS_FILE}
 
-apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply: apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 apply-cmd:
 	${TF_CMD_PREFIX} apply \
 	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
@@ -145,7 +145,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault

--- a/terraform13/terraform13-mfa-subfolder.mk
+++ b/terraform13/terraform13-mfa-subfolder.mk
@@ -122,11 +122,7 @@ format: ## The terraform fmt is used to rewrite tf conf files to a canonical for
 	${TF_CMD_MFA_PREFIX} fmt -recursive
 
 format-check: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
-	${TF_CMD_MFA_PREFIX} fmt -check
-    # Consider adding -recursive after everything has been migrated to tf-0.12
-	# (should exclude dev/8_k8s_kops/2-kops folder since it's not possible to migrate to
-	# tf-0.12 yet
-	# ${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
+	${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
 	docker run --security-opt="label:disable" --rm \
@@ -143,7 +139,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_MFA_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -156,7 +152,7 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_MFA_PREFIX} plan -out=plan.tfplan \
 	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
@@ -171,7 +167,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_MFA_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------

--- a/terraform13/terraform13-mfa.mk
+++ b/terraform13/terraform13-mfa.mk
@@ -122,11 +122,7 @@ format: ## The terraform fmt is used to rewrite tf conf files to a canonical for
 	${TF_CMD_MFA_PREFIX} fmt -recursive
 
 format-check: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
-	${TF_CMD_MFA_PREFIX} fmt -check
-    # Consider adding -recursive after everything has been migrated to tf-0.12
-	# (should exclude dev/8_k8s_kops/2-kops folder since it's not possible to migrate to
-	# tf-0.12 yet
-	# ${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
+	${TF_CMD_MFA_PREFIX} fmt -recursive -check ${TF_PWD_CONT_DIR}
 
 tflint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
 	docker run --security-opt="label:disable" --rm \
@@ -143,7 +139,7 @@ tflint-deep: ## TFLint is a Terraform linter for detecting errors that can not b
 	--aws-creds-file=/root/.aws/credentials \
 	--aws-region=${LOCAL_OS_AWS_REGION}
 
-force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 	${TF_CMD_MFA_PREFIX} force-unlock ${ARGS}
 
 decrypt: ## Decrypt secrets.tf via ansible-vault
@@ -156,7 +152,7 @@ encrypt: ## Encrypt secrets.dec.tf via ansible-vault
 validate-tf-layout: ## Validate Terraform layout to make sure it's set up properly
 	../../@bin/scripts/validate-terraform-layout.sh
 
-cost-estimate-plan: ## Terraform plan output compatible with https://terraform-cost-estimation.com/
+cost-estimate-plan: ## Terraform plan output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_MFA_PREFIX} plan -out=plan.tfplan \
 	 -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
@@ -171,7 +167,7 @@ cost-estimate-plan: ## Terraform plan output compatible with https://terraform-c
 	@echo ----------------------------------------------------------------------
 	@rm -rf terraform.jq plan.tfplan plan.json
 
-cost-estimate-state: ## Terraform state output compatible with https://terraform-cost-estimation.com/
+cost-estimate-state: ## Terraform state output compatible with terraform-cost-estimation.com
 	curl -sLO https://raw.githubusercontent.com/antonbabenko/terraform-cost-estimation/master/terraform.jq
 	${TF_CMD_MFA_PREFIX} state pull > state.json
 	@echo ----------------------------------------------------------------------


### PR DESCRIPTION
## What?
### Commits on Nov 18, 2020
@exequielrafaela - BBL-192 | 
- replace ':' chars in terraform mfa makefiles to show the complete help output 
- cmd renaming 
- tf format recursive cmd updated - 60facc8

## Why?
Currently some command ref help is not being shown as expected
```shell
Available Commands:
...
 - force-unlock        ## Manually unlock the terraform state, eg
...
```  

It must be:
`force-unlock: ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock`

## ✅ Validation 

```
╭─delivery at delivery-ops in ~/Binbash/repos/Leverage/ref-architecture/le-dev-makefiles/terraform13 on fix/BBL-192-tf-mfa-help✔ 20-11-18 - 21:32:22
╰─⠠⠵ make -f terraform13-mfa.mk
Available Commands:
 - apply               apply-cmd tf-dir-chown ## Make terraform apply any changes with dockerized binary
 - cost-estimate-plan  ## Terraform plan output compatible with terraform-cost-estimation.com
 - cost-estimate-state  ## Terraform state output compatible with terraform-cost-estimation.com
 - decrypt             ## Decrypt secrets.tf via ansible-vault
 - destroy             ## Destroy all resources managed by terraform
 - encrypt             ## Encrypt secrets.dec.tf via ansible-vault
 - force-unlock        ## Manually unlock the terraform state, eg make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
 - format-check        ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
 - format              ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
 - init                init-cmd tf-dir-chown ## Initialize terraform backend, plugins, and modules
 - init-reconfigure    init-reconfigure-cmd tf-dir-chown ## Initialize and reconfigure terraform backend, plugins, and modules
 - output              ## Terraform output command is used to extract the value of an output variable from the state file.
 - plan-detailed       ## Preview terraform changes with a more detailed output
 - plan                ## Preview terraform changes
 - shell               ## Initialize terraform backend, plugins, and modules
 - tf-dir-chown        ## run chown in ./.terraform to grant that the docker mounted dir has the right permissions
 - tflint-deep         ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
 - tflint              ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan (tf0.12 > 0.10.x).
 - validate-tf-layout  ## Validate Terraform layout to make sure it's set up properly
 - version             ## Show terraform version
```