### PR TITLE
Feature/BBL-192 | enabling tf mfa cache 

### DIFF
--- a/mkdocs/mkdocs-material.mk
+++ b/mkdocs/mkdocs-material.mk
@@ -5,7 +5,7 @@ SHELL                    := /bin/bash
 
 LOCAL_OS_USER_ID         = $(shell id -u)
 LOCAL_OS_GROUP_ID        = $(shell id -g)
-MKDOCS_DOCKER_IMG        := squidfunk/mkdocs-material:6.2.3
+MKDOCS_DOCKER_IMG        := squidfunk/mkdocs-material:6.2.4
 
 help:
 	@echo 'Available Commands:'

--- a/terraform13/terraform13-import-rm-mfa.mk
+++ b/terraform13/terraform13-import-rm-mfa.mk
@@ -35,6 +35,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \

--- a/terraform13/terraform13-mfa-github.mk
+++ b/terraform13/terraform13-mfa-github.mk
@@ -38,6 +38,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \
@@ -59,6 +60,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_CONFIG_FILE=/root/tmp/${PROJECT_SHORT}/config \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 --entrypoint=bash \
 -w ${TF_PWD_CONT_DIR} \

--- a/terraform13/terraform13-mfa-subfolder.mk
+++ b/terraform13/terraform13-mfa-subfolder.mk
@@ -35,6 +35,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=bash \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
@@ -55,6 +56,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \

--- a/terraform13/terraform13-mfa.mk
+++ b/terraform13/terraform13-mfa.mk
@@ -35,6 +35,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=bash \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
@@ -55,6 +56,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \

--- a/terraform14/terraform14-import-rm-mfa.mk
+++ b/terraform14/terraform14-import-rm-mfa.mk
@@ -35,6 +35,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \

--- a/terraform14/terraform14-mfa-github.mk
+++ b/terraform14/terraform14-mfa-github.mk
@@ -38,6 +38,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \
@@ -59,6 +60,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_CONFIG_FILE=/root/tmp/${PROJECT_SHORT}/config \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 --entrypoint=bash \
 -w ${TF_PWD_CONT_DIR} \

--- a/terraform14/terraform14-mfa-subfolder.mk
+++ b/terraform14/terraform14-mfa-subfolder.mk
@@ -35,6 +35,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=bash \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
@@ -55,6 +56,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \

--- a/terraform14/terraform14-mfa.mk
+++ b/terraform14/terraform14-mfa.mk
@@ -35,6 +35,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=bash \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
@@ -55,6 +56,7 @@ docker run --security-opt="label:disable" --rm \
 -e SRC_AWS_SHARED_CREDENTIALS_FILE=/root/tmp/${PROJECT_SHORT}/credentials \
 -e AWS_CONFIG_FILE=/root/.aws/${PROJECT_SHORT}/config \
 -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/${PROJECT_SHORT}/credentials \
+-e AWS_CACHE_DIR=/root/tmp/${PROJECT_SHORT}/cache \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -w ${TF_PWD_CONT_DIR} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER} \


### PR DESCRIPTION
## What? 
### Commits on Jan 13, 2021
- @exequielrafaela - BBL-192 | upgrading to latest mkdocs-material docker image ver - 8a08d17
- @exequielrafaela - BBL-192 | adding cache feature to terraform13-mfa makefiles - 6340f49
- @exequielrafaela - BBL-192 | adding cache feature to terraform14-mfa makefiles - b43f769
- @exequielrafaela - BBL-192 | adding cache feature to terraform12-mfa makefile - e22d537

## Why?
- It gets annoying to be prompt for MFA's OTP every time you run a terraform command
- Necessary to implement token timeout duration: https://github.com/binbashar/le-tf-infra-aws/blob/master/%40bin/scripts/aws-mfa/aws-mfa-entrypoint.sh#L162

## Expected Output

```
[01-11-21 14:56:44] [INFO] MFA: Found 2 profile/s
[01-11-21 14:56:44] [INFO] MFA: Attempting to get temporary credentials for profile=bb-apps-devstg-devops
[01-11-21 14:56:46] [INFO] MFA: Using cached credentials
[01-11-21 14:56:49] [INFO] MFA: Credentials written succesfully!
[01-11-21 14:56:49] [INFO] MFA: Attempting to get temporary credentials for profile=bb-shared-devops
[01-11-21 14:56:52] [INFO] MFA: Using cached credentials
[01-11-21 14:56:54] [INFO] MFA: Credentials written succesfully!
Initializing modules...
Initializing the backend...
Initializing provider plugins...
```
