### PR TITLE
feature/BBL-424 | adding infracost makefile --show-skipped flag

### DIFF
--- a/terraform12/terraform12-mfa.mk
+++ b/terraform12/terraform12-mfa.mk
@@ -198,4 +198,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform12/terraform12-subfolder.mk
+++ b/terraform12/terraform12-subfolder.mk
@@ -184,4 +184,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform12/terraform12.mk
+++ b/terraform12/terraform12.mk
@@ -184,4 +184,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform13/terraform13-mfa-subfolder.mk
+++ b/terraform13/terraform13-mfa-subfolder.mk
@@ -198,4 +198,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform13/terraform13-mfa.mk
+++ b/terraform13/terraform13-mfa.mk
@@ -198,4 +198,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform13/terraform13-subfolder.mk
+++ b/terraform13/terraform13-subfolder.mk
@@ -190,4 +190,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform13/terraform13.mk
+++ b/terraform13/terraform13.mk
@@ -190,4 +190,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform14/terraform14-mfa-subfolder.mk
+++ b/terraform14/terraform14-mfa-subfolder.mk
@@ -198,4 +198,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform14/terraform14-mfa.mk
+++ b/terraform14/terraform14-mfa.mk
@@ -198,4 +198,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform14/terraform14-subfolder.mk
+++ b/terraform14/terraform14-subfolder.mk
@@ -190,4 +190,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped

--- a/terraform14/terraform14.mk
+++ b/terraform14/terraform14.mk
@@ -190,4 +190,4 @@ cost-estimate-plan: ## Terraform plan cost estimate (https://www.infracost.io/),
 		-e INFRACOST_API_KEY=${INFRACOST_API_KEY} \
 		-v $$PWD/:/code/ \
 		--entrypoint=/usr/local/bin/infracost \
-		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json
+		binbash/terraform-infracost-slim:${TF_VER} --tfjson /code/plan.json --show-skipped


### PR DESCRIPTION
## What?
### Commits on Jan 21, 2021
- @exequielrafaela - BBL-424 | adding --show-skipped flag to understand which objetcs are still not supported by the infracost api in the calculations - 29477f5

## Why?
- [BBL-424 | Implement and test infracost tool w/ CI](https://trello.com/c/zkG7EvDf/424-bbl-424-implement-and-test-infracost-tool-w-ci)