### PR TITLE
Feature | updating material mkdocs version to its latests stable version

### DIFF
--- a/mkdocs/mkdocs-material.mk
+++ b/mkdocs/mkdocs-material.mk
@@ -5,7 +5,7 @@ SHELL                    := /bin/bash
 
 LOCAL_OS_USER_ID         = $(shell id -u)
 LOCAL_OS_GROUP_ID        = $(shell id -g)
-MKDOCS_DOCKER_IMG        := squidfunk/mkdocs-material:8.3.9
+MKDOCS_DOCKER_IMG        := squidfunk/mkdocs-material:9.0.12
 # GOOGLE_ANALYTICS_KEY: must be preset as os.ENV var
 
 help:


### PR DESCRIPTION
## What?

### Commits on Feb 16, 2023
- [updating material mkdocs version to its latests stable version](https://github.com/binbashar/le-dev-makefiles/commit/dc4231e49ffaddd1153df12b713546e4147b58b8) - @[exequielrafaela](https://github.com/binbashar/le-dev-makefiles/commits?author=exequielrafaela)

## Why? 
- Keeping https://leverage.binbash.com.ar material mkdocs based doc with the latest version, taking advantage of the some new features like improved Admonitions desing, "back to top" button and improved performance.  